### PR TITLE
Avoid usage of `new Buffer()`

### DIFF
--- a/lib/pickle.js
+++ b/lib/pickle.js
@@ -107,6 +107,9 @@ var PickleIterator = (function () {
 // space is controlled by the header_size parameter passed to the Pickle
 // constructor.
 var Pickle = (function () {
+  var emptyBuffer = typeof Buffer.alloc === 'function'
+    ? Buffer.alloc(0) : new Buffer(0)
+
   function Pickle (buffer) {
     if (buffer) {
       this.initFromBuffer(buffer)
@@ -116,7 +119,7 @@ var Pickle = (function () {
   }
 
   Pickle.prototype.initEmpty = function () {
-    this.header = new Buffer(0)
+    this.header = emptyBuffer
     this.headerSize = SIZE_UINT32
     this.capacityAfterHeader = 0
     this.writeOffset = 0
@@ -136,7 +139,7 @@ var Pickle = (function () {
       this.headerSize = 0
     }
     if (this.headerSize === 0) {
-      this.header = new Buffer(0)
+      this.header = emptyBuffer
     }
   }
 
@@ -212,7 +215,9 @@ var Pickle = (function () {
 
   Pickle.prototype.resize = function (newCapacity) {
     newCapacity = alignInt(newCapacity, PAYLOAD_UNIT)
-    this.header = Buffer.concat([this.header, new Buffer(newCapacity)])
+    var newBuffer = typeof Buffer.allocUnsafe === 'function'
+      ? Buffer.allocUnsafe(newCapacity) : new Buffer(+newCapacity)
+    this.header = Buffer.concat([this.header, newBuffer])
     this.capacityAfterHeader = newCapacity
   }
 


### PR DESCRIPTION
Using `new Buffer()` is deprecated and should be avoided.